### PR TITLE
Fix code issues preventing use with stable channel

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,6 @@
 //! [trace event format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
 //!
 
-#![feature(use_extern_macros)]
-
 #[cfg(feature = "rs_tracing")]
 extern crate serde;
 #[cfg(feature = "rs_tracing")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 //! [trace event format]: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview#
 //!
 
-#![feature(getpid)]
 #![feature(use_extern_macros)]
 
 #[cfg(feature = "rs_tracing")]


### PR DESCRIPTION
The currently only builds with the `nightly` channel as it uses `#![feature]`. Since all conditionally enabled features are now available in the `stable` channel, remove the attributes so `rs_tracing` can be used with `stable`.